### PR TITLE
Change the implementation of ListFrame to store elements in a fixed-size

### DIFF
--- a/src/include/CXXR/ListFrame.hpp
+++ b/src/include/CXXR/ListFrame.hpp
@@ -32,7 +32,7 @@
 #ifndef LISTFRAME_HPP
 #define LISTFRAME_HPP
 
-#include <list>
+#include <map>
 
 #include "CXXR/Allocator.hpp"
 #include "CXXR/Frame.hpp"
@@ -40,34 +40,58 @@
 namespace CXXR {
     /** @brief Lightweight implementation of CXXR::Frame.
      *
-     * This implementation is intended for Frames containing only a
-     * small number of Bindings.  Look-up time is linear in the number
-     * of Bindings.
+     * This implementation is intended for Frames which might contain
+     * only a small number of Bindings.  Look-up time is very fast and few
+     * memory allocations are required as long as the number of bindings
+     * is small.
+     * For large numbers of bindings, lookups and insertions are still O(1),
+     * but not as fast.
+     *
+     * This is implemented via a fixed-size unordered array of bindings.
+     * For small sizes, the linear scan through the array is fast and cache
+     * efficient.
+     * If more bindings are added to the frame than the array can store,
+     * the remaining bindings are added to a hashmap.  This ensures that
+     * the frame can handle large numbers of bindings reasonably efficiently.
      */
     class ListFrame : public Frame {
-    private:
-	typedef
-	std::list<Binding, CXXR::Allocator<Binding> > List;
     public:
-	ListFrame() { }
+	explicit ListFrame(size_t list_size = 16);
 	ListFrame(const ListFrame &pattern);
-
-	// Virtual functions of Frame (qv):
+	
+        // Virtual functions of Frame (qv):
 	void visitBindings(std::function<void(const Binding*)> f)
 	    const override;
 	ListFrame* clone() const override;
 	void lockBindings() override;
 	std::size_t size() const override;
-    private:
-	List m_list;
 
-	// Declared private to ensure that ListFrame objects are
+    protected:
+
+	// The main array that bindings are stored in.
+	// Note that the array cannot be moved or expanded, as there is a
+	// bunch of code (most notably the global cache) that keeps pointers
+	// to bindings.
+	Binding* m_bindings;
+	size_t m_bindings_size;
+	size_t m_used_bindings_size;
+	
+	// Used to store any bindings that don't fit in m_bindings.
+	// Usually this is nullptr.
+	std::map<const Symbol*, Binding>* m_overflow;
+
+	// Declared protected to ensure that ListFrame objects are
 	// created only using 'new':
-	~ListFrame() {}
+	~ListFrame() override;
 
-	// Not (yet) implemented.  Declared to prevent
-	// compiler-generated versions:
-	ListFrame& operator=(const ListFrame&);
+	ListFrame& operator=(const ListFrame&) = delete;
+
+	static bool isSet(const Binding& binding)
+	{
+	    return binding.frame() != nullptr;
+	}
+	
+	static void unsetBinding(Binding* binding);
 
 	// Virtual functions of Frame (qv):
 	void v_clear() override;
@@ -75,7 +99,6 @@ namespace CXXR {
 	Binding* v_obtainBinding(const Symbol* symbol) override;
 	Binding* v_binding(const Symbol* symbol) override;
 	const Binding* v_binding(const Symbol* symbol) const override;
-     };
-
+    };
 }  // namespace CXXR
 #endif // LISTFRAME_HPP

--- a/src/main/jit/CompiledFrame.cpp
+++ b/src/main/jit/CompiledFrame.cpp
@@ -31,18 +31,15 @@ namespace CXXR {
 namespace JIT {
 
 CompiledFrame::CompiledFrame(const FrameDescriptor* descriptor)
+    : ListFrame(descriptor->getNumberOfSymbols())
 {
     m_descriptor = descriptor;
-    m_bindings = new Binding[descriptor->getNumberOfSymbols()];
-    m_extension = nullptr;
+    m_used_bindings_size = m_bindings_size;
 }
 
 CompiledFrame::CompiledFrame(const CompiledFrame& pattern)
+    : CompiledFrame(pattern.m_descriptor)
 {
-    m_descriptor = pattern.m_descriptor;
-    m_bindings = new Binding[m_descriptor->getNumberOfSymbols()];
-    m_extension = nullptr;
-
     importBindings(&pattern);
     if (pattern.isLocked()) {
 	lock(false);
@@ -50,141 +47,39 @@ CompiledFrame::CompiledFrame(const CompiledFrame& pattern)
 }
 
 CompiledFrame::~CompiledFrame()
-{
-    delete[] m_bindings;
-    if (m_extension) {
-	delete m_extension;
-    }
-}
-
-Frame::Binding* CompiledFrame::v_binding(const Symbol* symbol)
-{
-    int location = m_descriptor->getLocation(symbol);
-    if (location != -1) {
-	return binding(location);
-    }
-    if (m_extension != nullptr) {
-	auto it = m_extension->find(symbol);
-	if (it != m_extension->end()) {
-	    return &(it->second);
-	}
-    }
-    return nullptr;
-}
-
-void CompiledFrame::visitBindings(std::function<void(const Binding*)> f) const
-{
-    const Binding* lastBinding
-	= m_bindings + m_descriptor->getNumberOfSymbols();
-    for (const Binding* binding = m_bindings; binding != lastBinding; ++binding)
-    {
-	if (isSet(*binding)) {
-	    f(binding);
-	}
-    }
-
-    if (m_extension) {
-	for (const auto& item : *m_extension) {
-	    const Binding* binding = &item.second;
-	    f(binding);
-	}
-    }
-}
+{ }
 
 CompiledFrame* CompiledFrame::clone() const
 {
     return new CompiledFrame(*this);
 }
 
-std::size_t CompiledFrame::size() const
-{
-  std::size_t result = 0;
-  for (int i = 0; i < m_descriptor->getNumberOfSymbols(); ++i) {
-    if (isSet(m_bindings[i])) {
-      result += 1;
-    }
-  }
-  if (m_extension) {
-    result += m_extension->size();
-  }
-  return result;
-}
-
-void CompiledFrame::lockBindings()
-{
-    int size = m_descriptor->getNumberOfSymbols();
-    for (int i = 0; i < size; i++) {
-	m_bindings[i].setLocking(true);
-    }
-    if (m_extension) {
-	for (auto& item : *m_extension) {
-	    item.second.setLocking(true);
-	}
-    }
-}
-
 void CompiledFrame::detachReferents()
 {
-    Frame::detachReferents();
+    ListFrame::detachReferents();
     m_descriptor.detach();
 }
 
 void CompiledFrame::visitReferents(const_visitor* v) const
 {
-    Frame::visitReferents(v);
+    ListFrame::visitReferents(v);
     (*v)(m_descriptor);
 }
 
-void CompiledFrame::v_clear()
-{
-    int size = m_descriptor->getNumberOfSymbols();
-    for (int i = 0; i < size; i++) {
-	unsetBinding(m_bindings + i);
-    }
-    if (m_extension) {
-	delete m_extension;
-	m_extension = nullptr;
-    }
-}
-
-bool CompiledFrame::v_erase(const Symbol* symbol)
-{
-    int location = m_descriptor->getLocation(symbol);
-    if (location != -1) {
-	Binding* binding = m_bindings + location;
-	if (isSet(*binding)) {
-	    unsetBinding(binding);
-	    return true;
-	}
-	return false;
-    }
-    if (m_extension) {
-	return m_extension->erase(symbol);
-    }
-    return false;
-}
-
+// Unlike ListFrame, the location to insert symbols is controlled by
+// the descriptor.
 Frame::Binding* CompiledFrame::v_obtainBinding(const Symbol* symbol)
 {
     int location = m_descriptor->getLocation(symbol);
     if (location != -1) {
 	return m_bindings + location;
     }
-    if (!m_extension) {
-	m_extension = new std::map<const Symbol*, Binding>();
+    if (!m_overflow) {
+	m_overflow = new std::map<const Symbol*, Binding>();
     }
-    return &((*m_extension)[symbol]);
+    return &((*m_overflow)[symbol]);
 }
 
-void CompiledFrame::unsetBinding(Binding* binding)
-{
-    if (!isSet(*binding)) {
-	return;
-    }
-    // Destroy the binding and create a new uninitialized one in its place.
-    binding->~Binding();
-    new (binding) Binding();
-}
 
 } // namespace JIT
 } // namespace CXXR


### PR DESCRIPTION
vector with overflow going to a hash map.

This removes the linked-list that was previously used in all cases and
should result in better performance both small frames and very large ones.

Make CompiledFrame inherit from the new ListFrame, which apart from
lacking a FrameDescriptor has an almost identical implementation now.