### PR TITLE
Removing CXXR private declarations from the public headers

### DIFF
--- a/src/include/CXXR/String.h
+++ b/src/include/CXXR/String.h
@@ -317,6 +317,13 @@ namespace CXXR {
      * empty string.
      */
     bool isASCII(const std::string& str);
+
+
+    // Designed for use with std::accumulate():
+    unsigned int stringWidth(unsigned int minwidth, const String* string);
+
+    // Designed for use with std::accumulate():
+    unsigned int stringWidthQuote(unsigned int minwidth, const String* string);
 }  // namespace CXXR
 
 extern "C" {

--- a/src/include/Defn.h
+++ b/src/include/Defn.h
@@ -46,10 +46,6 @@
 #ifndef DEFN_H_
 #define DEFN_H_
 
-#include "CXXR/BuiltInFunction.h"
-#include "CXXR/Evaluator.h"
-#include "CXXR/errors.h"
-
 #ifdef HAVE_VISIBILITY_ATTRIBUTE
 # define attribute_visible __attribute__ ((visibility ("default")))
 # define attribute_hidden __attribute__ ((visibility ("hidden")))

--- a/src/include/Print.h
+++ b/src/include/Print.h
@@ -32,12 +32,6 @@
 #include <R_ext/Print.h>
 
 #ifdef __cplusplus
-// namespace CXXR {
-//     unsigned int stringWidth(unsigned int minwidth,
-//                              const CXXR::String* string);
-//     unsigned int stringWidthQuote(unsigned int minwidth,
-// 			          const CXXR::String* string);
-// }
 
 extern "C" {
 #endif

--- a/src/include/Print.h
+++ b/src/include/Print.h
@@ -32,12 +32,12 @@
 #include <R_ext/Print.h>
 
 #ifdef __cplusplus
-namespace CXXR {
-    unsigned int stringWidth(unsigned int minwidth,
-                             const CXXR::String* string);
-    unsigned int stringWidthQuote(unsigned int minwidth,
-			          const CXXR::String* string);
-}
+// namespace CXXR {
+//     unsigned int stringWidth(unsigned int minwidth,
+//                              const CXXR::String* string);
+//     unsigned int stringWidthQuote(unsigned int minwidth,
+// 			          const CXXR::String* string);
+// }
 
 extern "C" {
 #endif

--- a/src/include/R_ext/GraphicsDevice.h
+++ b/src/include/R_ext/GraphicsDevice.h
@@ -33,7 +33,6 @@
 #define R_GRAPHICSDEVICE_H_
 
 /*#include <R_ext/GraphicsContext.h>*/
-#include "CXXR/RObject.h"
 
 /* ideally we would use prototypes in DevDesc.  
    Some devices have taken to passing pointers to their own structure

--- a/src/include/R_ext/GraphicsEngine.h
+++ b/src/include/R_ext/GraphicsEngine.h
@@ -28,8 +28,6 @@
 #ifndef R_GRAPHICSENGINE_H_
 #define R_GRAPHICSENGINE_H_
 
-#include "CXXR/String.h"
-
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/src/include/R_ext/Memory.h
+++ b/src/include/R_ext/Memory.h
@@ -35,8 +35,6 @@
 # include <stddef.h> /* for size_t */
 #endif
 
-#include "CXXR/RAllocStack.h"
-
 #ifdef  __cplusplus
 extern "C" {
 #endif

--- a/src/main/arithmetic.cpp
+++ b/src/main/arithmetic.cpp
@@ -69,6 +69,7 @@
 
 #include "CXXR/BinaryFunction.hpp"
 #include "CXXR/GCStackRoot.hpp"
+#include "CXXR/RAllocStack.h"
 #include "CXXR/UnaryFunction.hpp"
 
 using namespace CXXR;

--- a/src/main/array.cpp
+++ b/src/main/array.cpp
@@ -36,6 +36,7 @@
 #include <R_ext/Applic.h> /* for dgemm */
 
 #include "CXXR/GCStackRoot.hpp"
+#include "CXXR/RAllocStack.h"
 #include "CXXR/Subscripting.hpp"
 
 using namespace CXXR;

--- a/src/main/character.cpp
+++ b/src/main/character.cpp
@@ -88,6 +88,8 @@ abbreviate chartr make.names strtrim tolower toupper give error.
 
 #include <rlocale.h>
 
+#include "CXXR/RAllocStack.h"
+
 using namespace CXXR;
 
 /* We use a shared buffer here to avoid reallocing small buffers, and

--- a/src/main/connections.cpp
+++ b/src/main/connections.cpp
@@ -96,6 +96,7 @@
 #include <cstdarg>
 
 #include "CXXR/ProvenanceTracker.h"
+#include "CXXR/RAllocStack.h"
 
 using namespace std;
 using namespace CXXR;
@@ -6212,4 +6213,3 @@ SEXP R_new_custom_connection(const char *description, const char *mode, const ch
 
     return ans;
 }
-

--- a/src/main/dcf.cpp
+++ b/src/main/dcf.cpp
@@ -33,6 +33,8 @@
 
 #include <tre/tre.h>
 
+#include "CXXR/RAllocStack.h"
+
 static SEXP allocMatrixNA(SEXPTYPE, int, int);
 static void transferVector(SEXP s, SEXP t);
 

--- a/src/main/dotcode.cpp
+++ b/src/main/dotcode.cpp
@@ -39,6 +39,7 @@
 #include <boost/preprocessor.hpp>
 
 #include "CXXR/ClosureContext.hpp"
+#include "CXXR/RAllocStack.h"
 
 #ifndef max
 #define max(a, b) ((a > b)?(a):(b))

--- a/src/main/dounzip.cpp
+++ b/src/main/dounzip.cpp
@@ -43,6 +43,8 @@
 #include <io.h> /* for mkdir */
 #endif
 
+#include "CXXR/RAllocStack.h"
+
 /* cf do_dircreate in platform.c */
 static int R_mkdir(char *path)
 {

--- a/src/main/engine.cpp
+++ b/src/main/engine.cpp
@@ -35,6 +35,8 @@
 
 # include <rlocale.h>
 
+#include "CXXR/RAllocStack.h"
+
 int R_GE_getVersion()
 {
     return R_GE_version;

--- a/src/main/iosupport.cpp
+++ b/src/main/iosupport.cpp
@@ -50,6 +50,8 @@
 
 #include "IOStuff.h"
 
+#include "CXXR/RAllocStack.h"
+
 
 /* Move the iob->write_buf pointer to the next */
 /* BufferListItem in the chain. If there no next */

--- a/src/main/mapply.cpp
+++ b/src/main/mapply.cpp
@@ -30,6 +30,8 @@
 #include <Defn.h>
 #include <Internal.h>
 
+#include "CXXR/RAllocStack.h"
+
 SEXP attribute_hidden
 do_mapply(/*const*/ CXXR::Expression* call, const CXXR::BuiltInFunction* op, CXXR::Environment* rho, CXXR::RObject* const* args, int num_args, const CXXR::PairList* tags)
 {

--- a/src/main/platform.cpp
+++ b/src/main/platform.cpp
@@ -56,6 +56,7 @@
 #include "basedecl.h"
 #include <vector>
 #include "CXXR/Evaluator.h"
+#include "CXXR/RAllocStack.h"
 #include "CXXR/StackChecker.hpp"
 #include "CXXR/StringVector.h"
 

--- a/src/main/random.cpp
+++ b/src/main/random.cpp
@@ -36,6 +36,7 @@
 #include "basedecl.h"
 #include <errno.h>
 #include "CXXR/GCStackRoot.hpp"
+#include "CXXR/RAllocStack.h"
 
 using namespace CXXR;
 

--- a/src/main/raw.cpp
+++ b/src/main/raw.cpp
@@ -30,6 +30,8 @@
 #include <Defn.h>
 #include <Internal.h>
 
+#include "CXXR/RAllocStack.h"
+
 #define isRaw(x) (TYPEOF(x) == RAWSXP)
 
 /* charToRaw works at byte level, ignores encoding */

--- a/src/main/saveload.cpp
+++ b/src/main/saveload.cpp
@@ -43,6 +43,7 @@
 #include "CXXR/DottedArgs.hpp"
 #include "CXXR/GCStackRoot.hpp"
 #include "CXXR/ProvenanceTracker.h"
+#include "CXXR/RAllocStack.h"
 #include "CXXR/StdFrame.hpp"
 #include "CXXR/WeakRef.h"
 

--- a/src/main/sort.cpp
+++ b/src/main/sort.cpp
@@ -34,6 +34,8 @@
 #include <Rmath.h>
 #include <R_ext/RS.h>  /* for Calloc/Free */
 
+#include "CXXR/RAllocStack.h"
+
 // 'using namespace std' causes ambiguity of 'greater'
 using namespace CXXR;
 

--- a/src/main/unique.cpp
+++ b/src/main/unique.cpp
@@ -35,6 +35,7 @@
 #include "basedecl.h"
 #include "CXXR/ClosureContext.hpp"
 #include "CXXR/DottedArgs.hpp"
+#include "CXXR/RAllocStack.h"
 
 using namespace CXXR;
 

--- a/src/main/util.cpp
+++ b/src/main/util.cpp
@@ -36,6 +36,7 @@
 #include <vector>
 #include "CXXR/BuiltInFunction.h"
 #include "CXXR/ClosureContext.hpp"
+#include "CXXR/RAllocStack.h"
 
 #include <ctype.h>		/* for isspace */
 #include <float.h>		/* for DBL_MAX */


### PR DESCRIPTION
This patch removes such inclusions from all public headers, except Internal.h and Rinternals.h
