### PR TITLE
fix provenance build, using ./configure --enable-provenance-tracking

### DIFF
--- a/src/include/Rinternals.h
+++ b/src/include/Rinternals.h
@@ -530,7 +530,6 @@ SEXP Rf_allocMatrix(SEXPTYPE, int, int);
 SEXP Rf_allocList(unsigned int);
 SEXP Rf_allocS4Object(void);
 SEXP Rf_allocSExp(SEXPTYPE);
-/* SEXP Rf_allocVector(SEXPTYPE, R_xlen_t); -- EJP */
 SEXP Rf_allocVector3(SEXPTYPE, R_xlen_t, void*);
 R_xlen_t Rf_any_duplicated(SEXP x, Rboolean from_last);
 R_xlen_t Rf_any_duplicated3(SEXP x, SEXP incomp, Rboolean from_last);
@@ -1068,7 +1067,7 @@ Rboolean Rf_isVector(SEXP);
    It is *essential* that these do not appear in any other header file,
    with or without the Rf_ prefix.
 */
-/* SEXP     Rf_allocVector(SEXPTYPE, R_xlen_t); -- EJP */
+SEXP     Rf_allocVector(SEXPTYPE, R_xlen_t);
 Rboolean Rf_conformable(SEXP, SEXP);
 SEXP	 Rf_elt(SEXP, int);
 Rboolean Rf_inherits(SEXP, const char *);

--- a/src/include/Rinternals.h
+++ b/src/include/Rinternals.h
@@ -530,7 +530,7 @@ SEXP Rf_allocMatrix(SEXPTYPE, int, int);
 SEXP Rf_allocList(unsigned int);
 SEXP Rf_allocS4Object(void);
 SEXP Rf_allocSExp(SEXPTYPE);
-SEXP Rf_allocVector(SEXPTYPE, R_xlen_t);
+/* SEXP Rf_allocVector(SEXPTYPE, R_xlen_t); -- EJP */
 SEXP Rf_allocVector3(SEXPTYPE, R_xlen_t, void*);
 R_xlen_t Rf_any_duplicated(SEXP x, Rboolean from_last);
 R_xlen_t Rf_any_duplicated3(SEXP x, SEXP incomp, Rboolean from_last);
@@ -1068,7 +1068,7 @@ Rboolean Rf_isVector(SEXP);
    It is *essential* that these do not appear in any other header file,
    with or without the Rf_ prefix.
 */
-SEXP     Rf_allocVector(SEXPTYPE, R_xlen_t);
+/* SEXP     Rf_allocVector(SEXPTYPE, R_xlen_t); -- EJP */
 Rboolean Rf_conformable(SEXP, SEXP);
 SEXP	 Rf_elt(SEXP, int);
 Rboolean Rf_inherits(SEXP, const char *);

--- a/src/main/provenance_do.cpp
+++ b/src/main/provenance_do.cpp
@@ -218,17 +218,18 @@ do_provenance_graph(/*const*/ CXXR::Expression* call, const CXXR::BuiltInFunctio
     Rf_error(_("provenance tracking not implemented in this build"));
     return nullptr;
 #else
-    int nargs = length((CXXR::RObject*) args);
+    int nargs = num_args;
     if (nargs != 1)
 	Rf_error(_("%d arguments passed to 'provenance.graph' which requires 1"),
 		 nargs);
-    SEXP arg1 = CAR((CXXR::RObject*) args);
+    // SEXP arg1 = CAR((CXXR::RObject*) args);
+    const RObject* arg1 = args[0];
     if (!arg1 || arg1->sexptype() != STRSXP)
 	    Rf_error(_("invalid 'names' argument"));
 
     Environment* env = static_cast<Environment*>(rho);
     Provenance::Set provs;
-    StringVector* sv = static_cast<StringVector*>(arg1);
+    const StringVector* sv = static_cast<const StringVector*>(arg1);
     for (size_t i = 0; i < sv->size(); i++) {
 	const char* name = (*sv)[i]->c_str();
 	Symbol* sym = Symbol::obtain(name);

--- a/src/main/provenance_do.cpp
+++ b/src/main/provenance_do.cpp
@@ -37,6 +37,7 @@
 #include "CXXR/BuiltInFunction.h"
 #include "CXXR/IntVector.h"
 #include "CXXR/StringVector.h"
+#include "CXXR/RealVector.h" /* EJP */
 #include <Internal.h>
 
 #include <fstream>
@@ -190,7 +191,7 @@ SEXP attribute_hidden do_provenance (SEXP call, SEXP op, SEXP args, SEXP rho)
 #endif  // PROVENANCE_TRACKING
 }
 
-SEXP attribute_hidden do_provCommand (/*const*/ CXXR::Expression* call, const CXXR::BuiltInFunction* op, CXXR::Environment* rho, CXXR::RObject* const* args, int num_args, const CXXR::PairList* tags)
+SEXP attribute_hidden do_provCommand (/*const*/ CXXR::Expression* call, const CXXR::BuiltInFunction* op, CXXR::Environment* rho, CXXR::RObject* /* const* */ args, int num_args, const CXXR::PairList* tags)
 {
 #ifndef PROVENANCE_TRACKING
     Rf_error(_("provenance tracking not implemented in this build"));
@@ -217,11 +218,11 @@ do_provenance_graph(/*const*/ CXXR::Expression* call, const CXXR::BuiltInFunctio
     Rf_error(_("provenance tracking not implemented in this build"));
     return nullptr;
 #else
-    int nargs = length(args);
+    int nargs = length((CXXR::RObject*) args);
     if (nargs != 1)
 	Rf_error(_("%d arguments passed to 'provenance.graph' which requires 1"),
 		 nargs);
-    SEXP arg1 = CAR(args);
+    SEXP arg1 = CAR((CXXR::RObject*) args);
     if (!arg1 || arg1->sexptype() != STRSXP)
 	    Rf_error(_("invalid 'names' argument"));
 


### PR DESCRIPTION
this fixes the multiple definitions of Rf_allocVector error on Ubuntu 14.04, gcc 4.8.4, and fixes building using --enable-provenance-tracking