### PR TITLE
Fix for localized regression tests

### DIFF
--- a/tests/CXXR/Makefile.in
+++ b/tests/CXXR/Makefile.in
@@ -67,7 +67,7 @@ UnitTests: $(UNIT_TEST_OBJECTS) GTestWithR_main.o FORCE # ../../src/main/libR.a
 FORCE:
 
 UnitTests.ts : UnitTests
-	LD_LIBRARY_PATH=../../lib R_DEFAULT_PACKAGES=NULL R_HOME=$(R_HOME) ./$<
+	LC_ALL=C LD_LIBRARY_PATH=../../lib R_DEFAULT_PACKAGES=NULL R_HOME=$(R_HOME) ./$<
 	touch $@
 
 ArgMatchertest.o : ArgMatchertest.cpp


### PR DESCRIPTION
Some regression tests compare output error/warning messages. Comparison works for english locale only.